### PR TITLE
Pass tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var expressions = [
 function message(form, path, expression, match) {
   var word = match[0]
   return {
-    message: "'" + word + "' repeats a written number and numeral, which is redundant and error-prone'",
+    message: '"' + word + '" repeats a written number and numeral, which is redundant and error-prone',
     level: "info",
     path: path,
     source: 'doubleplus-numbers',

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var expressions = [
   /five \(5\)/ ]
 
 function message(form, path, expression, match) {
-  var word = match[1]
+  var word = match[0]
   return {
     message: "'" + word + "' repeats a written number and numeral, which is redundant and error-prone'",
     level: "info",


### PR DESCRIPTION
There were two things going on:

First, RegExp match data includes the entire string matched by a regular expression as `match[0]`, rather than `match[1]`. See [MDN's page on `RegExp.prototype.exec`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec).

Second, an even smaller thing, I fixed the kinds of quotation marks around the matched string to match your test case's annotation message.
