### PR TITLE
Configure npm to ignore dotfiles

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.gitignore
+.npmignore
+.travis.yml


### PR DESCRIPTION
This tiny PR adds a file called `.npmignore` that works much like for `.gitignore`, but for npm, to keep extra files out of distributed packages.

Try:

``` shellsession
$ npm pack
$ tar tvf doubleplus*
```
